### PR TITLE
Fix requeue freezed jobs

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -295,6 +295,7 @@ class Job(object):
         job_.model_name = stored.model_name if stored.model_name else None
         job_.retry = stored.retry
         job_.max_retries = stored.max_retries
+        job_.worker_pid = stored.worker_pid
         if stored.company_id:
             job_.company_id = stored.company_id.id
         return job_
@@ -456,6 +457,7 @@ class Job(object):
         self._eta = None
         self.eta = eta
         self.channel = channel
+        self.worker_pid = None
 
     def perform(self):
         """ Execute the job.
@@ -498,6 +500,7 @@ class Job(object):
                 'date_done': False,
                 'eta': False,
                 'identity_key': False,
+                'worker_pid': False
                 }
         dt_to_string = odoo.fields.Datetime.to_string
         if self.date_enqueued:
@@ -510,6 +513,8 @@ class Job(object):
             vals['eta'] = dt_to_string(self.eta)
         if self.identity_key:
             vals['identity_key'] = self.identity_key
+        if self.worker_pid:
+            vals['worker_pid'] = self.worker_pid
 
         db_record = self.db_record()
         if db_record:
@@ -585,6 +590,7 @@ class Job(object):
         self.state = PENDING
         self.date_enqueued = None
         self.date_started = None
+        self.worker_pid = None
         if reset_retry:
             self.retry = 0
         if result is not None:
@@ -594,10 +600,12 @@ class Job(object):
         self.state = ENQUEUED
         self.date_enqueued = datetime.now()
         self.date_started = None
+        self.worker_pid = None
 
     def set_started(self):
         self.state = STARTED
         self.date_started = datetime.now()
+        self.worker_pid = os.getpid()
 
     def set_done(self, result=None):
         self.state = DONE

--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -7,6 +7,7 @@ import functools
 import hashlib
 import logging
 import uuid
+import os
 import sys
 from datetime import datetime, timedelta
 

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -358,7 +358,7 @@ class QueueJob(models.Model):
             counter += 1
 
             #DO NOT REQUEUE A JOB IF ITS PID IS STILL RUNNING
-            if job.state == STARTED and job.worker_pid != False and check_pid(job.worker_pid):
+            if job.state == STARTED and job.worker_pid != False and job.check_pid():
                 _logger.info('SKIPPING requeue job %s, its corresponding process %s is still running' % (job.uuid, job.worker_pid))
 
             if job.retry < job.max_retries:

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -360,6 +360,7 @@ class QueueJob(models.Model):
             #DO NOT REQUEUE A JOB IF ITS PID IS STILL RUNNING
             if job.state == STARTED and job.worker_pid != False and job.check_pid():
                 _logger.info('SKIPPING requeue job %s, its corresponding process %s is still running' % (job.uuid, job.worker_pid))
+                continue
 
             if job.retry < job.max_retries:
                 # send warning message

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -2,6 +2,7 @@
 # Copyright 2013-2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+import os
 import logging
 from datetime import datetime, timedelta
 
@@ -87,6 +88,7 @@ class QueueJob(models.Model):
                           index=True)
 
     identity_key = fields.Char()
+    worker_pid = fields.Integer(readonly=True)
 
     @api.model_cr
     def init(self):
@@ -355,6 +357,10 @@ class QueueJob(models.Model):
             _logger.info('JOB: %s' % job)
             counter += 1
 
+            #DO NOT REQUEUE A JOB IF ITS PID IS STILL RUNNING
+            if job.state == STARTED and job.worker_pid != False and check_pid(job.worker_pid):
+                _logger.info('SKIPPING requeue job %s, its corresponding process %s is still running' % (job.uuid, job.worker_pid))
+
             if job.retry < job.max_retries:
                 # send warning message
                 if job.job_function_id.channel_id.notify and job.state == 'started':
@@ -384,6 +390,8 @@ class QueueJob(models.Model):
 
                 # we don't use requeue() to prevent reset retry counter
                 job._change_job_state(PENDING, False)
+                #unset pid
+                job.worker_pid = False
                 _logger.info("force requeue job id %s" % job.id)
 
             else:
@@ -395,6 +403,15 @@ class QueueJob(models.Model):
                     _logger.info("force to fail job id %s" % job.id)
 
         return counter
+
+    def check_pid(self):        
+        """ Check For the existence of a unix pid. """
+        try:
+            os.kill(self.worker_pid, 0)
+        except OSError:
+            return False
+        else:
+            return True
 
 
 class RequeueJob(models.TransientModel):

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -217,6 +217,25 @@ class QueueJob(models.Model):
         )
         tracking_disable = False if config_model and config_model.value == 'True' else True
 
+        #handle corner case that can happen because Odoo DB connection management sucks
+        #a job that crashed due to DB connection issues will stay in 'started' mode indefinitely 
+        #and block the queue channel
+        #if a job in 'started' state with the same worker_pid exists, it's certainly blocked due to the reason above, force requeue it
+        #no need to check for different pid as the current job is not yet in started state ('write' operation happens below)
+        if vals.get('state') == 'started' and vals.get('worker_pid'):
+            blocked_domain = [
+            ('state', '=', STARTED),
+            ('worker_pid', '=', vals.get('worker_pid')),
+            ]
+            
+            blocked_jobs = self.search(blocked_domain)
+            for job in blocked_jobs:
+                # we don't use requeue() to prevent reset retry counter
+                job._change_job_state(PENDING, False)
+                #unset pid
+                job.worker_pid = False
+                _logger.info("force requeue blocked job id %s, uuid %s, because a new job started with the same worker_pid %s" % (job.id, job.uuid, vals.get('worker_pid')))
+        
         self = self.with_context(tracking_disable=tracking_disable)
         res = super(QueueJob, self).write(vals)
 
@@ -403,6 +422,25 @@ class QueueJob(models.Model):
                     job.write({'state': 'failed'})
                     _logger.info("force to fail job id %s" % job.id)
 
+        #always requeue jobs that are stuck in 'started' state for more than one hour, regardless of pid status and channel
+        one_hour_ago = (
+            datetime.now() - timedelta(minutes=60)
+        ).strftime(
+            DEFAULT_SERVER_DATETIME_FORMAT
+        )
+        jobs_started_blocked_hour = self.env['queue.job'].search([
+            ('state', '=', STARTED),
+            ('date_started', '<', one_hour_ago)
+        ])
+        
+        for job in jobs_started_blocked_hour:
+            _logger.info('JOB STUCK IN STARTED FOR MORE THAN ONE HOUR: %s' % job)
+            # we don't use requeue() to prevent reset retry counter
+            job._change_job_state(PENDING, False)
+            #unset pid
+            job.worker_pid = False
+            _logger.info("force requeue job id %s, because it was stuck in 'started' state for more than one hour" % job.id)
+            
         return counter
 
     def check_pid(self):        


### PR DESCRIPTION
Fix requeue freezed jobs:
- added worker pid reference to jobs (set when job is started)
- a job gets automatically enqueued again if it's in "started" state and a new job starts with the same pid (means the first job crashed and was unable to update job state)
- a job gets automatically enqueued again if it's in "started" state and its worker pid no longer exists
- a job stuck in "started" for more than 1 hour gets automatically enqueued again, regardless of channel or worker pid status